### PR TITLE
Publish JAR to GitHub packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,13 @@ jobs:
       - name: clean PR ref name
         run: |
           echo "CLEAN_REF_NAME=${{ github.ref_name }}" | sed 's/\//-/g' >> $GITHUB_ENV
+      - name: setup conda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+            auto-activate-base: false
+      - name: build models
+        run: |
+          make models
       - name: Build JAR
         run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-SNAPSHOT --file flfm-ij/pom.xml
       - name: Upload JAR to GitHub Packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,13 @@ jobs:
           distribution: 'temurin'
           java-version: '8'
           cache: 'maven'
+      - name: clean PR ref name
+        run: |
+          echo "CLEAN_REF_NAME=${{ github.ref_name }}" | sed 's/\//-/g' >> $GITHUB_ENV
       - name: Build JAR
-        run: mvn -B package --file flfm-ij/pom.xml
+        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-SNAPSHOT --file flfm-ij/pom.xml
       - name: Upload JAR to GitHub Packages
-        run: mvn --batch-mode deploy --file flfm-ij/pom.xml
+        run: mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-SNAPSHOT --file flfm-ij/pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,10 +82,14 @@ jobs:
       - name: build models
         run: |
           make models
-      - name: Build JAR
-        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-SNAPSHOT --file flfm-ij/pom.xml
-      - name: Upload JAR to GitHub Packages
-        run: mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-SNAPSHOT --file flfm-ij/pom.xml
+      - name: Build JAR for Linux
+        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux-SNAPSHOT --file flfm-ij/pom.xml -P linux-cuda
+      - name: Build JAR for Windows
+        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-windows-SNAPSHOT --file flfm-ij/pom.xml -P windows-cuda
+      - name: Upload JAR(s) to GitHub Packages
+        run: |
+          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux-SNAPSHOT --file flfm-ij/pom.xml
+          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-widows-SNAPSHOT --file flfm-ij/pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Upload JAR(s) to GitHub Packages
         run: |
           mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml
-          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-widows${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml
+          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-windows${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,9 @@ jobs:
       - name: clean PR ref name
         run: |
           echo "CLEAN_REF_NAME=${{ github.ref_name }}" | sed 's/\//-/g' >> $GITHUB_ENV
+      - name: set jar version SNAPSHOT suffix for PRs only
+        if: github.event_name == 'pull_request'
+        run: echo "VERSION_SUFFIX=-SNAPSHOT" >> $GITHUB_ENV
       - name: setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -83,13 +86,13 @@ jobs:
         run: |
           make models
       - name: Build JAR for Linux
-        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux-SNAPSHOT --file flfm-ij/pom.xml -P linux-cuda
+        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml -P linux-cuda
       - name: Build JAR for Windows
-        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-windows-SNAPSHOT --file flfm-ij/pom.xml -P windows-cuda
+        run: mvn -B package -Dapp.version=${{ env.CLEAN_REF_NAME }}-windows${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml -P windows-cuda
       - name: Upload JAR(s) to GitHub Packages
         run: |
-          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux-SNAPSHOT --file flfm-ij/pom.xml
-          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-widows-SNAPSHOT --file flfm-ij/pom.xml
+          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-linux${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml
+          mvn --batch-mode deploy -Dapp.version=${{ env.CLEAN_REF_NAME }}-widows${{ env.VERSION_SUFFIX }} --file flfm-ij/pom.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,9 +58,12 @@ jobs:
          fail_ci_if_error: true
 
   build:
-    name: Build JAR with Maven
+    name: Build and Publish JAR with Maven
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 8
@@ -71,11 +74,10 @@ jobs:
           cache: 'maven'
       - name: Build JAR
         run: mvn -B package --file flfm-ij/pom.xml
-      - name: Upload JAR artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: flfm-ij-plugin-jar
-          path: flfm-ij/target/*.jar
+      - name: Upload JAR to GitHub Packages
+        run: mvn --batch-mode deploy --file flfm-ij/pom.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # publish:
   #   name: Publish Docker image

--- a/flfm-ij/pom.xml
+++ b/flfm-ij/pom.xml
@@ -6,19 +6,20 @@
 
   <groupId>ssec.jhu.edu</groupId>
   <artifactId>flfm</artifactId>
-  <!-- TODO: make this dynamic-->
-  <version>1.0-SNAPSHOT</version>
+  <version>${app.version}</version>
   <name>FLFM</name>
   <url>https://github.com/ssec-jhu/flfm-ij-plugin</url>
   <description>This is an ImageJ 1.x plugin wrapper for the JHU SSEC FLFM (https://github.com/ssec-jhu/flfm) project.</description>
 
   <!-- This needs to be 1.8 to work with ImageJ 1.x -->
   <properties>
+    <app.version>1.0.0-SNAPSHOT</app.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <djl.version>0.32.0</djl.version>
     <org.checkstyle.google.severity>error</org.checkstyle.google.severity>
   </properties>
+
 
   <!-- This is the BOM used for DJL versioning: https://docs.djl.ai/master/bom/index.html-->
   <dependencyManagement>

--- a/flfm-ij/pom.xml
+++ b/flfm-ij/pom.xml
@@ -404,5 +404,12 @@
     </profile>
   </profiles>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/ssec-jhu/flfm-ij-plugin</url>
+    </repository>
+  </distributionManagement>
 
 </project>

--- a/makefile
+++ b/makefile
@@ -37,7 +37,7 @@ models: clean-models $(MODEL_FILES)
 
 # generate the windows jar file
 windows: $(MODEL_FILES)
-	mvn package -f flfm-ij/pom.xml -P windows-cudas
+	mvn package -f flfm-ij/pom.xml -P windows-cuda
 
 # Generate the linux jar file
 linux: $(MODEL_FILES)


### PR DESCRIPTION
Resolves #10 

Docs: [[Publishing JAR packages to GitHub Packages](https://docs.github.com/en/actions/tutorials/publish-packages/publish-java-packages-with-maven#publishing-packages-to-github-packages)](https://docs.github.com/en/actions/tutorials/publish-packages/publish-java-packages-with-maven#publishing-packages-to-github-packages)

Two part PR:

- [x] push jar to github packages (just to test it works as described)
- [x] The jar needs to contain the exported models and thus the build needs to also create the models.
- [x] Publish linux and Windows jars
